### PR TITLE
chore: 빌드 에러 수정

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -6,7 +6,6 @@
       <module name="AndroidSdk.buildSrc" target="21" />
       <module name="AndroidSdk.buildSrc.main" target="21" />
       <module name="AndroidSdk.buildSrc.test" target="21" />
-      <module name="AndroidSdk.sdk" target="21" />
       <module name="iamport-android.buildSrc" target="11" />
     </bytecodeTargetLevel>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,12 +7,10 @@ android {
     namespace 'com.iamport.sampleapp'
 
     compileSdk 35
-    buildToolsVersion = '34.0.0'
 
     defaultConfig {
         applicationId "com.iamport.sampleapp"
         minSdkVersion 21
-        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -42,8 +40,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_21
-        targetCompatibility JavaVersion.VERSION_21
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildFeatures {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.defaults.buildfeatures.buildconfig=true
+

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -1,3 +1,19 @@
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+kotlin {
+    jvmToolchain(17)
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
 plugins {
     id("com.android.library")
 //    id("com.android.application")
@@ -13,7 +29,6 @@ android {
     namespace = "com.iamport.sdk"
 
     compileSdk = 35
-    buildToolsVersion = "34.0.0"
 
     defaultConfig {
         minSdk = 21
@@ -46,12 +61,13 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     buildFeatures {
         dataBinding = true
+        buildConfig = true
     }
 
     lint {
@@ -142,8 +158,4 @@ dependencies {
     implementation(Libs.workRuntimeKtx)
 
     implementation(Libs.lottie)
-}
-
-kotlin {
-    jvmToolchain(21)
 }


### PR DESCRIPTION
jitpack배포가 실패하여 Kotlin과 Java 컴파일러 모두가 JVM 17을 타겟되도록 수정하였습니다.
./gradlew publishToMavenLocal 를 통해 로컬에서 성공여부를 확인 하였습니다..!